### PR TITLE
reset cru moved after link mask set

### DIFF
--- a/src/Cru/CruDmaChannel.cxx
+++ b/src/Cru/CruDmaChannel.cxx
@@ -89,8 +89,6 @@ CruDmaChannel::~CruDmaChannel()
 
 void CruDmaChannel::deviceStartDma()
 {
-  resetCru();
-
   // Enable links
   uint32_t mask = 0xFfffFfff;
   for (const auto& link : mLinks) {
@@ -127,6 +125,9 @@ void CruDmaChannel::deviceStartDma()
         << ErrorInfo::Message("CRU only supports 'None' loopback when operating without data generator"));
     }
   }
+
+  // Reset CRU (should be done after link mask set)
+  resetCru();
 
   // Initialize link queues
   for (auto &link : mLinks) {


### PR DESCRIPTION
feature was not working properly, readout was often stuck after changing list of links. resetCru() has to be done after writing 0x604 