### PR TITLE
Set loopback mode when none is provided and generator is enabled.

### DIFF
--- a/src/CommandLineUtilities/ProgramDmaBench.cxx
+++ b/src/CommandLineUtilities/ProgramDmaBench.cxx
@@ -196,6 +196,11 @@ class ProgramDmaBench: public Program
       params.setDmaPageSize(mOptions.dmaPageSize);
       params.setGeneratorEnabled(mOptions.generatorEnabled);
       params.setGeneratorLoopback(LoopbackMode::fromString(mOptions.loopbackModeString));
+      // If the Generator is enabled and no LoopbackMode was specified, fallback to Internal
+      if (params.getGeneratorEnabled() && params.getGeneratorLoopback() == LoopbackMode::None) {
+        getLogger() << "No loopback mode value specified, defaulting to 'Internal'" << endm;
+        params.setGeneratorLoopback(LoopbackMode::Internal);
+      }
 
       // Handle file output options
       {

--- a/src/Crorc/CrorcDmaChannel.cxx
+++ b/src/Crorc/CrorcDmaChannel.cxx
@@ -33,7 +33,7 @@ CrorcDmaChannel::CrorcDmaChannel(const Parameters& parameters)
     mInitialResetLevel(ResetLevel::Internal), // It's good to reset at least the card channel in general
     mNoRDYRX(true), // Not sure
     mUseFeeAddress(false), // Not sure
-    mLoopbackMode(parameters.getGeneratorLoopback().get_value_or(LoopbackMode::Internal)), // Internal loopback by default
+    mLoopbackMode(parameters.getGeneratorLoopback().get_value_or(LoopbackMode::None)), // No loopback by default
     mGeneratorEnabled(parameters.getGeneratorEnabled().get_value_or(true)), // Use data generator by default
     mGeneratorPattern(parameters.getGeneratorPattern().get_value_or(GeneratorPattern::Incremental)), //
     mGeneratorMaximumEvents(0), // Infinite events
@@ -64,6 +64,11 @@ CrorcDmaChannel::CrorcDmaChannel(const Parameters& parameters)
     }
     mReadyFifoAddressUser = entry.addressUser;
     mReadyFifoAddressBus = entry.addressBus;
+  }
+  // If the Generator is enabled and no LoopbackMode was specified, fallback to Internal
+  if (mGeneratorEnabled && mLoopbackMode == LoopbackMode::None) {
+    log("No loopback mode specified; defaulting to 'Internal'", InfoLogger::InfoLogger::Info);
+    mLoopbackMode = LoopbackMode::Internal;
   }
 
   getReadyFifoUser()->reset();

--- a/src/Crorc/CrorcDmaChannel.h
+++ b/src/Crorc/CrorcDmaChannel.h
@@ -171,7 +171,7 @@ class CrorcDmaChannel final : public DmaChannelPdaBase
     const bool mUseFeeAddress;
 
     /// Gives the type of loopback
-    const LoopbackMode::type mLoopbackMode;
+    LoopbackMode::type mLoopbackMode;
 
     /// Enables the data generator
     const bool mGeneratorEnabled;

--- a/src/Cru/CruDmaChannel.cxx
+++ b/src/Cru/CruDmaChannel.cxx
@@ -22,7 +22,7 @@ CruDmaChannel::CruDmaChannel(const Parameters& parameters)
       mPdaBar2(getRocPciDevice().getPciDevice(), 2), // Initialize BAR 2
       mFeatures(getBar().getFirmwareFeatures()), // Get which features of the firmware are enabled
       mInitialResetLevel(ResetLevel::Internal), // It's good to reset at least the card channel in general
-      mLoopbackMode(parameters.getGeneratorLoopback().get_value_or(LoopbackMode::Internal)), // Internal loopback by default
+      mLoopbackMode(parameters.getGeneratorLoopback().get_value_or(LoopbackMode::None)), // No loopback by default
       mGeneratorEnabled(parameters.getGeneratorEnabled().get_value_or(true)), // Use data generator by default
       mGeneratorPattern(parameters.getGeneratorPattern().get_value_or(GeneratorPattern::Incremental)), //
       mGeneratorDataSizeRandomEnabled(parameters.getGeneratorRandomSizeEnabled().get_value_or(false)), //
@@ -71,6 +71,12 @@ CruDmaChannel::CruDmaChannel(const Parameters& parameters)
       mLinks.push_back({static_cast<LinkId>(id)});
     }
     log(stream.str());
+  }
+  
+  // If the Generator is enabled and no LoopbackMode was specified, fallback to Internal
+  if (mGeneratorEnabled && mLoopbackMode == LoopbackMode::None) {
+    log("No loopback mode specified; defaulting to 'Internal'", InfoLogger::InfoLogger::Info);
+    mLoopbackMode = LoopbackMode::Internal;
   }
 }
 

--- a/src/Cru/CruDmaChannel.h
+++ b/src/Cru/CruDmaChannel.h
@@ -126,34 +126,34 @@ class CruDmaChannel final : public DmaChannelPdaBase
     // These variables are configuration parameters
 
     /// Reset level on initialization of channel
-    ResetLevel::type mInitialResetLevel;
+    const ResetLevel::type mInitialResetLevel;
 
     /// Gives the type of loopback
     LoopbackMode::type mLoopbackMode;
 
     /// Enables the data generator
-    bool mGeneratorEnabled;
+    const bool mGeneratorEnabled;
 
     /// Data pattern for the data generator
-    GeneratorPattern::type mGeneratorPattern;
+    const GeneratorPattern::type mGeneratorPattern;
 
     /// Random data size
-    bool mGeneratorDataSizeRandomEnabled;
+    const bool mGeneratorDataSizeRandomEnabled;
 
     /// Maximum number of events
-    int mGeneratorMaximumEvents;
+    const int mGeneratorMaximumEvents;
 
     /// Initial value of the first data in a data block
-    uint32_t mGeneratorInitialValue;
+    const uint32_t mGeneratorInitialValue;
 
     /// Sets the second word of each fragment when the data generator is used
-    uint32_t mGeneratorInitialWord;
+    const uint32_t mGeneratorInitialWord;
 
     /// Random seed parameter in case the data generator is set to produce random data
-    int mGeneratorSeed;
+    const int mGeneratorSeed;
 
     /// Length of data written to each page
-    size_t mGeneratorDataSize;
+    const size_t mGeneratorDataSize;
 };
 
 } // namespace roc

--- a/src/DmaChannelBase.cxx
+++ b/src/DmaChannelBase.cxx
@@ -13,18 +13,6 @@
 
 namespace AliceO2 {
 namespace roc {
-namespace {
-void checkParameters(const Parameters& parameters)
-{
-  // Generator enabled is not allowed in conjunction with none loopback mode
-  auto enabled = parameters.getGeneratorEnabled();
-  auto loopback = parameters.getGeneratorLoopback();
-  if (enabled && loopback && (*enabled && (*loopback == LoopbackMode::None))) {
-    BOOST_THROW_EXCEPTION(
-        InvalidParameterException() << ErrorInfo::Message("Generator enabled but 'None' loopback mode specified"));
-  }
-}
-} // Anonymous namespace
 
 namespace b = boost;
 namespace bfs = boost::filesystem;
@@ -52,9 +40,6 @@ DmaChannelBase::DmaChannelBase(CardDescriptor cardDescriptor, const Parameters& 
 
   // Check the channel number is allowed
   checkChannelNumber(allowedChannels);
-
-  // Do some basic Parameters validity checks
-  checkParameters(parameters);
 
   // Create parent directories
   auto paths = getPaths();


### PR DESCRIPTION
Propagated the responsibility of setting a loopback mode to the individual DMA channels. Otherwise the parameters could not remain const in the base and derived classes. 