### PR TITLE
Properly link and generate config for Python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,8 @@ target_link_libraries(ReadoutCard
     AliceO2::Common
     $<$<BOOL:${Python2_FOUND}>:Boost::python27>
     $<$<BOOL:${Python2_FOUND}>:Python2::Python>
+    $<$<BOOL:${Python3_FOUND}>:Boost::python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}>
+    $<$<BOOL:${Python3_FOUND}>:Python3::Python>
   PRIVATE
     $<$<BOOL:${PDA_FOUND}>:pda::pda>
     Boost::filesystem

--- a/cmake/ReadoutCardConfig.cmake.in
+++ b/cmake/ReadoutCardConfig.cmake.in
@@ -7,8 +7,15 @@ set(Common_CMAKE_DIR @Common_DIR@)
 set(InfoLogger_CMAKE_DIR @InfoLogger_ROOT@)
 
 if(NOT APPLE)
-  set(boost_python_component "python27")
-  find_dependency(Python2 2.7 COMPONENTS Development REQUIRED)
+  find_package(Python3 3.6 COMPONENTS Development)
+  if(Python3_FOUND)
+    set(boost_python_component "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
+  else()
+    # Backwards compatible. Can be removed once the Python3 recipe is stable
+    message(WARNING "Python 3 was not found: falling back to Python 3")
+    find_package(Python2 2.7 COMPONENTS Development REQUIRED)
+    set(boost_python_component "python27")
+  endif()
 endif()
 
 find_dependency(Common CONFIG HINTS ${Common_CMAKE_DIR})


### PR DESCRIPTION
* Generation of ReadoutCardConfig.cmake is now fixed and detects Python 3 and
  `boost_pythonXY` properly
* Target `libReadoutCard.*` now gets correctly linked to the Python 3 libraries
  as well