### PR TITLE
[ORC-201] Improve Python3 detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ ENDIF()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 if(NOT APPLE)
-  find_package(Python3 3.6 COMPONENTS Development)
+  find_package(Python3 3.6 COMPONENTS Interpreter Development)
   if(Python3_FOUND)
     set(boost_python_component "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
   else()


### PR DESCRIPTION
Without this fix the python3 that is detected is not the one built by aliBuild but the one on the system (and that one is not the one Boost has been compiled against).

Well, at least that was the observation on my system, based on the 
[readout.log](https://github.com/AliceO2Group/ReadoutCard/files/3338598/readout.log) of the build failure, where the relevant lines are : 

```
-- Found Python3: /home/aphecetche/.asdf/installs/python/3.7.3/lib/libpython3.7m.so (found suitable version "3.7.3", minimum required is "3.6") found components:  Development
CMake Error at /home/aphecetche/alice/qc/sw/slc7_x86-64/CMake/v3.13.1-1/share/cmake-3.13/Modules/FindBoost.cmake:2100 (message):
  Unable to find the requested Boost libraries.

  Boost version: 1.68.0

  Boost include path:
  /home/aphecetche/alice/qc/sw/slc7_x86-64/boost/v1.68.0-4/include

  Could not find the following Boost libraries:

          boost_python37

  Some (but not all) of the required Boost libraries were found.  You may
  need to install these additional Boost libraries.  Alternatively, set
  BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT
  to the location of Boost.
Call Stack (most recent call first):
  CMakeLists.txt:72 (find_package)
```

Once that fix is applied, the detection gives : 

```
-- Found Python3: /home/aphecetche/alice/qc/sw/slc7_x86-64/Python/v3.6.8-1/bin/python3.6 (found suitable version "3.6.8", minimum required is "3.6") found components:  Interpreter Development
```

For the record on that particular system the available (through asdf tool) pythons are 3.7.3 and 2.7.14.

```
~/alice/qc$ asdf current python
3.7.3 2.7.14 (set by /home/aphecetche/alice/qc/.tool-versions)
``` 