### PR TITLE
Upgrade clang-format check to clang-format-11

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,24 +3,31 @@ name: Clang format
 on: [pull_request]
 
 jobs:
-  clang-format-8:
+  clang-format:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-    - name: Run clang-foramt on changed files
+
+    - name: Install prerequisites
+      run: |
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
+        sudo update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-11 100
+
+    - name: Run clang-format on changed files
       run: |
         set -x
-        git fetch origin ${{ github.event.pull_request.base.ref }}
-        git fetch origin pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}
-        BASE_COMMIT=$(git rev-parse ${{ github.event.pull_request.base.sha }})
-        COMMIT_FILES=$(git diff --name-only ${BASE_COMMIT} | grep -i -v LinkDef)
-        RESULT_OUTPUT=$(git-clang-format-8 --commit ${BASE_COMMIT} --diff --binary $(which clang-format-8) ${COMMIT_FILES})
-        if [ "$RESULT_OUTPUT" == "no modified files to format" ] || [ "$RESULT_OUTPUT" == "clang-format did not modify any files" ]; then
+        git fetch origin ${{ github.event.pull_request.base.ref }} pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}
+        base_commit=$(git rev-parse ${{ github.event.pull_request.base.sha }})
+        result_output=$(git diff --diff-filter d --name-only "$base_commit" -- . ':^LinkDef' |
+                          xargs -d '\n' git-clang-format --commit "$base_commit" --diff --style file)
+        if [ "$result_output" = 'no modified files to format' ] ||
+           [ "$result_output" = 'clang-format did not modify any files' ]
+        then
           exit 0
         else
-          git-clang-format-8 --commit $BASE_COMMIT --diff --binary $(which clang-format-8)
-          echo "$RESULT_OUTPUT"
+          git-clang-format --commit "$base_commit" --diff --style file
+          echo "$result_output"
           exit 1
         fi  


### PR DESCRIPTION
Due to a recent update of GitHub's ubuntu-latest containers, git-clang-format-8 stopped working. This updates it to clang-format-11, which is in line with the clang version used for compilation.