### PR TITLE
Add a `roc-metrics` flag to force metrics report even with invalid SNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ In order to use a CRU the package versions have to adhere to the following table
 | v0.26.0     | v3.9.1.        | v2.7.0         | v1.1.0+     | v12.0.0      |
 | v0.27.0     | v3.9.1/v3.10.0 | v2.7.0         | v1.1.0+     | v12.0.0      |
 | v0.32.1     | v3.9.1/v3.10.0 | v2.7.0/v2.8.0  | v1.1.0+     | v12.0.0      |
+| v0.33.0     | v3.9.1-v3.12.0 | v2.7.0-v2.8.1  | v1.1.0+     | v12.0.0      |
 
 The _PDA Driver_ entry refers to the `pda-kadapter-dkms-*.rpm` package which is availabe through the [o2-daq-yum](http://alice-daq-yum-o2.web.cern.ch/alice-daq-yum-o2/cc7_64/) repo as an RPM.
 

--- a/src/FirmwareChecker.cxx
+++ b/src/FirmwareChecker.cxx
@@ -23,9 +23,12 @@ namespace roc
 
 FirmwareChecker::FirmwareChecker() : mCompatibleFirmwareList({
                                        /* CRU */
+                                       { "6a85d30c", "v3.12.0" },
+                                       { "7be5aa1c", "v3.11.0" },
                                        { "e4a5a46e", "v3.10.0" },
                                        { "f71faa86", "v3.9.1" },
                                        { "8e0d2ffa", "v3.9.0" },
+                                       { "0c6a3a7c", "MFT PSU" },
                                        /*{ "e8e58cff", "v3.8.0" },
                                                                { "f8cecade", "v3.7.0" },
                                                                { "75b96268", "v3.6.1" },
@@ -33,6 +36,7 @@ FirmwareChecker::FirmwareChecker() : mCompatibleFirmwareList({
                                                                { "d458317e", "v3.5.2" },
                                                                { "6baf11da", "v3.5.1" },*/
                                        /* CRORC */
+                                       { "59e9955", "v2.8.1" },
                                        { "f086417", "v2.8.0" },
                                        { "474f9e1", "v2.7.0" }
                                        /*{ "8e3a98e", "v2.6.1" },


### PR DESCRIPTION
Closes ORC-420 & ORC-421