### PR TITLE
[cru/dma] Revert data-taking link UP check for now

### DIFF
--- a/src/Cru/CruBar.cxx
+++ b/src/Cru/CruBar.cxx
@@ -933,7 +933,8 @@ std::vector<int> CruBar::getDataTakingLinks()
   for (auto const& el : linkMap) {
     int id = el.first;
     Link link = el.second;
-    if (!datapathWrapper.isLinkEnabled(link) || gbt.getStickyBit(link) == Cru::LinkStatus::Down) {
+    // TODO: Check for link UP disabled until clear what will happen with the case of TPC UL
+    if (!datapathWrapper.isLinkEnabled(link) /* || gbt.getStickyBit(link) == Cru::LinkStatus::Down */) {
       continue;
     }
     links.push_back(id);


### PR DESCRIPTION
There is a case for the TPC User Logic where the link UP check excludes a link from data-taking. Disabling the check until resolution.