### PR TITLE
Revert "[cru] User Logic hash register disabled"

### DIFF
--- a/src/Cru/Constants.h
+++ b/src/Cru/Constants.h
@@ -151,9 +151,7 @@ static constexpr Register FIRMWARE_TIME(0x0000000c);
 
 /// Register containing the userlogic Git hash
 /// Must be accessed on BAR 2
-/// Keep the same address as the COMMON LOGIC until register is implemented for all detectors
-//static constexpr Register USERLOGIC_GIT_HASH(0x00c00004);
-static constexpr Register USERLOGIC_GIT_HASH(0x4);
+static constexpr Register USERLOGIC_GIT_HASH(0x00c00004);
 
 /// Register containing the first part of the Arria 10 chip ID
 /// Must be accessed on BAR 2


### PR DESCRIPTION
This reverts commit 0a00f37eadf8a5aa4963432c3125660de1407486.